### PR TITLE
Remove duplicate function name

### DIFF
--- a/snippets/objects.cson
+++ b/snippets/objects.cson
@@ -21,7 +21,7 @@
 
   "Object method":
     prefix: "km"
-    body: """${1:methodName}: function ${1:methodName}(${2}) {
+    body: """${1:methodName}: function(${2}) {
       $0
     }${3:,}
     """


### PR DESCRIPTION
When adding a function to an object I prefer not writing the function name twice.

myCoolMethod: function() {}

vs

myCoolMethod: function myCoolMethod()
